### PR TITLE
Warn on structs with `compare?/1`

### DIFF
--- a/lib/compare_chain.ex
+++ b/lib/compare_chain.ex
@@ -31,6 +31,9 @@ defmodule CompareChain do
 
   You must include at least one comparison like `<` in your expression.
   Failing to do so will result in a compile time error.
+
+  Including a struct in the expression will result in a warning.
+  You probably want to use `compare?/2` instead.
   """
   defmacro compare?(expr) do
     ast = quote(do: unquote(expr))
@@ -43,7 +46,6 @@ defmodule CompareChain do
 
   This is like how you can provide a module as the second argument to
   `Enum.sort/2`.
-  See the notes in `compare?/1` as they apply to `compare?/2` as well.
 
   ## Examples
 
@@ -99,6 +101,12 @@ defmodule CompareChain do
     iex> end
     iex> compare?(1 > 2 > 3, AlwaysGreaterThan)
     true
+    ```
+
+  ## Notes
+
+  You must include at least one comparison like `<` in your expression.
+  Failing to do so will result in a compile time error.
     ```
   """
   defmacro compare?(expr, module) do

--- a/lib/compare_chain.ex
+++ b/lib/compare_chain.ex
@@ -107,7 +107,6 @@ defmodule CompareChain do
 
   You must include at least one comparison like `<` in your expression.
   Failing to do so will result in a compile time error.
-    ```
   """
   defmacro compare?(expr, module) do
     ast = quote(do: unquote(expr))

--- a/lib/compare_chain/default_compare.ex
+++ b/lib/compare_chain/default_compare.ex
@@ -1,10 +1,44 @@
 defmodule CompareChain.DefaultCompare do
   @moduledoc false
+  require Logger
+
   def compare(left, right) do
+    if is_struct(left) or is_struct(right) do
+      message = struct_warning_message(left, right)
+
+      Logger.warning(message)
+    end
+
     cond do
       left < right -> :lt
       left > right -> :gt
       left == right -> :eq
     end
   end
+
+  defp struct_warning_message(%match{} = left, %match{} = right) do
+    """
+    Performing structural comparison on matching structs.
+
+    Did you mean to use `compare?/2`?
+
+      compare?(#{inspect(left)} ??? #{inspect(right)}, #{struct_string(left)})
+    """
+  end
+
+  defp struct_warning_message(left, right) do
+    """
+    Performing structural comparison on one or more mismatched structs.
+
+    Left#{if(is_struct(left), do: " (%#{struct_string(left)}{} struct)", else: "")}:
+
+      #{inspect(left)}
+
+    Right#{if(is_struct(right), do: " (%#{struct_string(right)}{} struct)", else: "")}:
+
+      #{inspect(right)}
+    """
+  end
+
+  defp struct_string(%s{}), do: s |> Atom.to_string() |> String.replace_leading("Elixir.", "")
 end

--- a/test/compare_chain_test.exs
+++ b/test/compare_chain_test.exs
@@ -28,7 +28,7 @@ defmodule CompareChainTest do
       end)
 
     assert warning_message =~ """
-           Performing structural comparison on one or more mismatched structs.
+           [warning] Performing structural comparison on one or more mismatched structs.
 
            Left (%Date{} struct):
 

--- a/test/compare_chain_test.exs
+++ b/test/compare_chain_test.exs
@@ -21,6 +21,40 @@ defmodule CompareChainTest do
     end)
   end
 
+  test "compare?/1 with mismatched structs raises warning" do
+    warning_message =
+      ExUnit.CaptureLog.capture_log(fn ->
+        compare?(~D[2022-01-02] < ~T[00:00:00])
+      end)
+
+    assert warning_message =~ """
+           Performing structural comparison on one or more mismatched structs.
+
+           Left (%Date{} struct):
+
+             ~D[2022-01-02]
+
+           Right (%Time{} struct):
+
+             ~T[00:00:00]
+           """
+  end
+
+  test "compare?/1 with matching structs raises warning with a hint" do
+    warning_message =
+      ExUnit.CaptureLog.capture_log(fn ->
+        compare?(~D[2022-01-02] < ~D[2022-02-01])
+      end)
+
+    assert warning_message =~ """
+           [warning] Performing structural comparison on matching structs.
+
+           Did you mean to use `compare?/2`?
+
+             compare?(~D[2022-01-02] ??? ~D[2022-02-01], Date)
+           """
+  end
+
   test "works with boolean literals" do
     assert compare?((true and 1 < 2) or false)
   end


### PR DESCRIPTION
## Description

This PR adds warnings for when `compare?/1` is used on structs. For example:

```elixir
iex> compare?(~D[2022-01-02] < ~D[2022-02-01])
false
```

Raises the following warning (modulo the timestamp):

```
16:08:26.256 [warning] Performing structural comparison on matching structs.

Did you mean to use `compare?/2`?

  compare?(~D[2022-01-02] ??? ~D[2022-02-01], Date)
```

## Related Links

* Closes: https://github.com/CargoSense/compare_chain/issues/3